### PR TITLE
Expand environment variables in the file path.

### DIFF
--- a/src/NReco.Logging.File/FileLoggerProvider.cs
+++ b/src/NReco.Logging.File/FileLoggerProvider.cs
@@ -59,7 +59,7 @@ namespace NReco.Logging.File {
 		}
 
 		public FileLoggerProvider(string fileName, FileLoggerOptions options) {
-			LogFileName = fileName;
+			LogFileName = Environment.ExpandEnvironmentVariables(fileName);
 			Append = options.Append;
 			FileSizeLimitBytes = options.FileSizeLimitBytes;
 			MaxRollingFiles = options.MaxRollingFiles;

--- a/test/NReco.Logging.Tests/FileProviderTests.cs
+++ b/test/NReco.Logging.Tests/FileProviderTests.cs
@@ -184,15 +184,6 @@ namespace NReco.Logging.Tests
 				factory.Dispose();
 
 				Assert.Equal(1, System.IO.File.ReadAllLines(expandedTmpFileName).Length);
-
-				factory = new LoggerFactory();
-				logger = factory.CreateLogger("TEST");
-				factory.AddProvider(new FileLoggerProvider(tmpFileWithEnvironmentVariable, false));
-				logger.LogInformation("Line2");
-				factory.Dispose();
-
-				Assert.Equal(1, System.IO.File.ReadAllLines(expandedTmpFileName).Length);  // file should be overwritten
-
 			}
 			finally
 			{

--- a/test/NReco.Logging.Tests/FileProviderTests.cs
+++ b/test/NReco.Logging.Tests/FileProviderTests.cs
@@ -170,5 +170,36 @@ namespace NReco.Logging.Tests
 			}
 		}
 
+		[Fact]
+		public void ExpandEnvironmentVariables()
+		{
+			var tmpFileWithEnvironmentVariable = "%TEMP%\\" + Path.GetFileName(Path.GetTempFileName());
+			var expandedTmpFileName = Path.Combine(Path.GetTempPath(), Path.GetFileName(tmpFileWithEnvironmentVariable));
+			try
+			{
+				var factory = new LoggerFactory();
+				factory.AddProvider(new FileLoggerProvider(tmpFileWithEnvironmentVariable, false));
+				var logger = factory.CreateLogger("TEST");
+				logger.LogInformation("Line1");
+				factory.Dispose();
+
+				Assert.Equal(1, System.IO.File.ReadAllLines(expandedTmpFileName).Length);
+
+				factory = new LoggerFactory();
+				logger = factory.CreateLogger("TEST");
+				factory.AddProvider(new FileLoggerProvider(tmpFileWithEnvironmentVariable, false));
+				logger.LogInformation("Line2");
+				factory.Dispose();
+
+				Assert.Equal(1, System.IO.File.ReadAllLines(expandedTmpFileName).Length);  // file should be overwritten
+
+			}
+			finally
+			{
+				System.IO.File.Delete(expandedTmpFileName);
+			}
+
+		}
+
 	}
 }


### PR DESCRIPTION
Allows specifying for example %TEMP%\MyGreatProduct.log in the filename.