### PR TITLE
Bug workaround for Issue #28 The process cannot access the file

### DIFF
--- a/src/NReco.Logging.File/FileLoggerOptions.cs
+++ b/src/NReco.Logging.File/FileLoggerOptions.cs
@@ -52,7 +52,7 @@ namespace NReco.Logging.File {
 		/// If true and a log file fails to open for writing, this will silently skip to the next possible file.
 		/// </summary>
 		/// <remarks>Only applicable when <see cref="MaxRollingFiles"/> is greater than 1. Provides limited recovery from temporary IO issues affecting individual files.</remarks>
-		public bool SkipErroneousLogFiles { get; set; } = true;
+		public bool SkipUnopenableLogFiles { get; set; } = true;
 
 		/// <summary>
 		/// Custom formatter for the log entry line. 

--- a/src/NReco.Logging.File/FileLoggerOptions.cs
+++ b/src/NReco.Logging.File/FileLoggerOptions.cs
@@ -49,6 +49,12 @@ namespace NReco.Logging.File {
 		public int MaxRollingFiles { get; set; } = 0;
 
 		/// <summary>
+		/// If true and a log file fails to open for writing, this will silently skip to the next possible file.
+		/// </summary>
+		/// <remarks>Only applicable when <see cref="MaxRollingFiles"/> is greater than 1. Provides limited recovery from temporary IO issues affecting individual files.</remarks>
+		public bool SkipErroneousLogFiles { get; set; } = true;
+
+		/// <summary>
 		/// Custom formatter for the log entry line. 
 		/// </summary>
 		public Func<LogMessage, string> FormatLogEntry { get; set; }

--- a/src/NReco.Logging.File/FileLoggerProvider.cs
+++ b/src/NReco.Logging.File/FileLoggerProvider.cs
@@ -183,11 +183,6 @@ namespace NReco.Logging.File {
 			/// <param name="append"></param>
 			void OpenNextAvailableFile(bool append, bool tryExistingFilenameFirst)
 			{
-				// Flush and close what we have open
-				// This is necessary as GetNextFileLogName reads the file size
-				// as written to disk
-				Close();
-
 				HashSet<string> attempted = new HashSet<string>();
 				List<IOException> exceptions = null;
 

--- a/src/NReco.Logging.File/FileLoggerProvider.cs
+++ b/src/NReco.Logging.File/FileLoggerProvider.cs
@@ -44,7 +44,7 @@ namespace NReco.Logging.File {
 		private readonly bool Append = true;
 		private readonly long FileSizeLimitBytes = 0;
 		private readonly int MaxRollingFiles = 0;
-		private readonly bool SkipErroneousLogFiles = true;
+		private readonly bool SkipUnopenableLogFiles = true;
 
 		public LogLevel MinLevel { get; set; } = LogLevel.Trace;
 
@@ -72,7 +72,7 @@ namespace NReco.Logging.File {
 			FormatLogEntry = options.FormatLogEntry;
 			FormatLogFileName = options.FormatLogFileName;
 			MinLevel = options.MinLevel;
-			SkipErroneousLogFiles = options.SkipErroneousLogFiles;
+			SkipUnopenableLogFiles = options.SkipUnopenableLogFiles;
 
 			fWriter = new FileWriter(this);
 			processQueueTask = Task.Factory.StartNew(
@@ -234,7 +234,7 @@ namespace NReco.Logging.File {
 					exception = null;
 					return true;
 				}
-				catch (IOException e) when (FileLogPrv.SkipErroneousLogFiles)
+				catch (IOException e) when (FileLogPrv.SkipUnopenableLogFiles)
 				{
 					// It's possible that the file is in use by another process,
 					// temporary IO problems or or permissions issues have arisen

--- a/src/NReco.Logging.File/FileLoggerProvider.cs
+++ b/src/NReco.Logging.File/FileLoggerProvider.cs
@@ -263,6 +263,12 @@ namespace NReco.Logging.File {
 
 			string GetNextFileLogName() {
 				var baseLogFileName = GetBaseLogFileName();
+
+				if (FileLogPrv.FileSizeLimitBytes <= 0) {
+					// Rolling files is disabled
+					// Always use the same file
+					return baseLogFileName;
+				}
 				
 				int currentFileIndex = 0;
 				var baseFileNameOnly = Path.GetFileNameWithoutExtension(baseLogFileName);

--- a/test/NReco.Logging.Tests/FileProviderTests.cs
+++ b/test/NReco.Logging.Tests/FileProviderTests.cs
@@ -199,7 +199,7 @@ namespace NReco.Logging.Tests
 		}
 
 		/// <summary>
-		/// Checks an error is thrown if the file to write to is busy and skipping is disables
+		/// Checks an error is thrown if the file to write to is busy and skipping is disabled
 		/// </summary>
 		[Fact]
 		public void ThrowIfFilesInUse() {

--- a/test/NReco.Logging.Tests/FileProviderTests.cs
+++ b/test/NReco.Logging.Tests/FileProviderTests.cs
@@ -225,7 +225,7 @@ namespace NReco.Logging.Tests
 								{
 									FileSizeLimitBytes = 1024 * 8,
 									MaxRollingFiles = 1,
-									SkipErroneousLogFiles = false
+									SkipUnopenableLogFiles = false
 								}))
 							);
 
@@ -236,7 +236,7 @@ namespace NReco.Logging.Tests
 								{
 									FileSizeLimitBytes = 1024 * 8,
 									MaxRollingFiles = 1,
-									SkipErroneousLogFiles = true
+									SkipUnopenableLogFiles = true
 								}))
 								);
 
@@ -247,7 +247,7 @@ namespace NReco.Logging.Tests
 							{
 								FileSizeLimitBytes = 1024 * 8,
 								MaxRollingFiles = 10,
-								SkipErroneousLogFiles = false
+								SkipUnopenableLogFiles = false
 							}))
 							);
 						}


### PR DESCRIPTION
This is designed to make the logger a bit more robust to files being busy. See Issue #28. It's not a full solution as I did not manage to fully diagnose the issue.

The changes are thus:

- There is a new option called `SkipUnopenableLogFiles` which is `true` by default
- If this is off **or** the solution only writes to a single log file, behaviour is similar to before
- If this is on **and** multiple log files is allowed, it attempts to open the log file to write to as normal. However, upon an `IOException` it recovers and moves to attempting to use the next log file.
- If it cannot open any files for writing, it throws an `AggregateException` containing the `IOException`s.

Other minor changes:

- `FileWriter` now implements `IDisposable` (because it opens a stream). Although this is unlikely to change behaviour meaningfully it's a tad more 'correct' and might help with some more advanced debugging at some point(?).
- Removed logic regarding `"// if file does not exist or file size limit is not reached - do not add rolling file index"` as it caused problems with the new logic (forces retrying to open busy files). The overall behaviour seems to be unchanged due to the circumstances in which this is now called.
- Added in tests for the new behaviour
- Slightly more defensive programming for a few disposes in case of `Exception` in `Dispose`, but again unlikely to explain the issue fully.

What I have _not_ done is check whether concurrency issues could explain the issue at hand, somehow. It could be worth a think and I might revisit this if I can get the issue to be reproducible locally in the future.

Tests all pass locally.