### PR TITLE
BC: Fix: #61 NReco's FileLoggerExtensions should NOT be in the Micros…

### DIFF
--- a/src/NReco.Logging.File/FileLogger.cs
+++ b/src/NReco.Logging.File/FileLogger.cs
@@ -13,22 +13,17 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.IO;
-using System.Collections.Concurrent;
 using System.Text;
 
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Configuration;
 
-namespace NReco.Logging.File {
+namespace NReco.Logging.File
+{
 
-	/// <summary>
-	/// Generic file logger that works in a similar way to standard ConsoleLogger.
-	/// </summary>
-	public class FileLogger : ILogger {
+    /// <summary>
+    /// Generic file logger that works in a similar way to standard ConsoleLogger.
+    /// </summary>
+    public class FileLogger : ILogger {
 
 		private readonly string logName;
 		private readonly FileLoggerProvider LoggerPrv;

--- a/src/NReco.Logging.File/FileLoggerConfig.cs
+++ b/src/NReco.Logging.File/FileLoggerConfig.cs
@@ -12,16 +12,7 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.IO;
-using System.Collections.Concurrent;
-using System.Text;
-
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Configuration;
 
 namespace NReco.Logging.File
 {
@@ -62,6 +53,4 @@ namespace NReco.Logging.File
         /// </summary>
         public LogLevel MinLevel { get; set; } = LogLevel.Trace;
     }
-
-
 }

--- a/src/NReco.Logging.File/FileLoggerExtensions.cs
+++ b/src/NReco.Logging.File/FileLoggerExtensions.cs
@@ -13,15 +13,10 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.IO;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-
-using NReco.Logging.File;
 
 namespace NReco.Logging.File
 {

--- a/src/NReco.Logging.File/FileLoggerExtensions.cs
+++ b/src/NReco.Logging.File/FileLoggerExtensions.cs
@@ -19,10 +19,11 @@ using System.IO;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using NReco.Logging.File;
 
-namespace Microsoft.Extensions.Logging
+namespace NReco.Logging.File
 {
 
     public static class FileLoggerExtensions

--- a/src/NReco.Logging.File/FileLoggerOptions.cs
+++ b/src/NReco.Logging.File/FileLoggerOptions.cs
@@ -13,15 +13,8 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.IO;
-using System.Collections.Concurrent;
-using System.Text;
 
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Configuration;
 
 namespace NReco.Logging.File
 {

--- a/src/NReco.Logging.File/FileLoggerProvider.cs
+++ b/src/NReco.Logging.File/FileLoggerProvider.cs
@@ -13,22 +13,20 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.IO;
 using System.Collections.Concurrent;
-using System.Text;
 
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Configuration;
 
-namespace NReco.Logging.File {
+namespace NReco.Logging.File
+{
 
-	/// <summary>
-	/// Generic file logger provider.
-	/// </summary>
-	[ProviderAlias("File")]
+    /// <summary>
+    /// Generic file logger provider.
+    /// </summary>
+    [ProviderAlias("File")]
 	public class FileLoggerProvider : ILoggerProvider {
 
 		private string LogFileName;

--- a/src/NReco.Logging.File/LogMessage.cs
+++ b/src/NReco.Logging.File/LogMessage.cs
@@ -13,13 +13,12 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Text;
+
 using Microsoft.Extensions.Logging;
 
 namespace NReco.Logging.File
 {
-	public struct LogMessage {
+    public struct LogMessage {
 		public readonly string LogName;
 		public readonly string Message;
 		public readonly LogLevel LogLevel;

--- a/src/NReco.Logging.File/NReco.Logging.File.csproj
+++ b/src/NReco.Logging.File/NReco.Logging.File.csproj
@@ -5,7 +5,7 @@
 	
 How to use:
 
-services.AddLogging(loggingBuilder => {
+services.AddLogging(loggingBuilder =&gt; {
 	loggingBuilder.AddFile("app.log", append:true);
 });
 
@@ -17,7 +17,7 @@ More details and examples: https://github.com/nreco/logging
     <VersionPrefix>1.1.7</VersionPrefix>
     <Authors>Vitalii Fedorchenko</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>False</GenerateDocumentationFile>
     <AssemblyName>NReco.Logging.File</AssemblyName>
     <PackageId>NReco.Logging.File</PackageId>
     <PackageTags>log;file;logging;asp.net;file-logger;logging-provider;netstandard;netcore</PackageTags>
@@ -74,9 +74,9 @@ Version 1.0.4 changes:
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
     
 </Project>

--- a/test/NReco.Logging.Tests/AssemblyInfo.cs
+++ b/test/NReco.Logging.Tests/AssemblyInfo.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+// In SDK-style projects such as this one, several assembly attributes that were historically
+// defined in this file are now automatically added during build and populated with
+// values defined in project properties. For details of which attributes are included
+// and how to customise this process see: https://aka.ms/assembly-info-properties
+
+
+// Setting ComVisible to false makes the types in this assembly not visible to COM
+// components.  If you need to access a type in this assembly from COM, set the ComVisible
+// attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM.
+
+[assembly: Guid("98be00b3-2f67-4434-98be-d20cedb5272f")]
+
+// See https://xunit.net/xunit.analyzers/rules/xUnit1031
+[assembly: SuppressMessage("xUnit", "xUnit1031", Justification = "Parallelization is disabled")]

--- a/test/NReco.Logging.Tests/FileProviderTests.cs
+++ b/test/NReco.Logging.Tests/FileProviderTests.cs
@@ -23,7 +23,7 @@ namespace NReco.Logging.Tests
 				logger.LogInformation("Line1");
 				factory.Dispose();
 
-				Assert.Equal(1, System.IO.File.ReadAllLines(tmpFile).Length);
+				Assert.Single(System.IO.File.ReadAllLines(tmpFile));
 
 				factory = new LoggerFactory();
 				logger = factory.CreateLogger("TEST");
@@ -31,7 +31,7 @@ namespace NReco.Logging.Tests
 				logger.LogInformation("Line2");
 				factory.Dispose();
 
-				Assert.Equal(1, System.IO.File.ReadAllLines(tmpFile).Length);  // file should be overwritten
+				Assert.Single(System.IO.File.ReadAllLines(tmpFile));  // file should be overwritten
 
 			} finally {
 				System.IO.File.Delete(tmpFile);
@@ -148,11 +148,11 @@ namespace NReco.Logging.Tests
 							}
 						})
 					);
+                }
+                Task.WaitAll(writeTasks.ToArray());
 
-				}
-				Task.WaitAll(writeTasks.ToArray());
+                factory.Dispose();
 
-				factory.Dispose();
 				int lines = 0;
 				using (var fileStream = new FileStream(tmpFile, FileMode.Open, FileAccess.Read)) {
 					using (var rdr = new StreamReader(fileStream)) {
@@ -393,7 +393,7 @@ namespace NReco.Logging.Tests
 
 				var logLines = System.IO.File.ReadAllLines(logFileName);
 				Assert.Single(logLines);
-				Assert.False(logLines[0].Contains("TEST2"));
+				Assert.DoesNotContain(logLines[0], "TEST2");
 			} finally {
 				CleanupTempDir(tmpDir, new[] { factory });
 			}

--- a/test/NReco.Logging.Tests/NReco.Logging.Tests.csproj
+++ b/test/NReco.Logging.Tests/NReco.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>NReco.Logging.Tests</AssemblyName>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -11,10 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" /> 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.6.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This fixes #61.
Updated xunit, disabled xml doc generation (causing 14 warnings), and added AssemblyInfo.cs file in order to suppress an xunit warning that seems safe to ignore for now.