### PR TITLE
Added default ILoggingBuilder extension

### DIFF
--- a/src/NReco.Logging.File/FileLoggerExtensions.cs
+++ b/src/NReco.Logging.File/FileLoggerExtensions.cs
@@ -74,12 +74,17 @@ namespace NReco.Logging.File {
 		/// </summary>
 		/// <remarks>File logger is not added if "File" section is not present or it doesn't contain "Path" property.</remarks>
 		public static ILoggingBuilder AddFile(this ILoggingBuilder builder, Action<FileLoggerOptions> configure = null) {
-			builder.Services.AddSingleton<ILoggerProvider>(
-				(srvPrv) => {
-					IConfigurationSection loggingSection = srvPrv.GetRequiredService<IConfiguration>().GetSection("Logging");
-					return CreateFromConfiguration(loggingSection, configure) ?? NullLoggerProvider.Instance;
+			IConfigurationSection loggingSection = builder.Services.BuildServiceProvider().GetService<IConfiguration>()?.GetSection("Logging");
+			if (loggingSection != null) {
+				FileLoggerProvider fileLoggerPrv = CreateFromConfiguration(loggingSection, configure);
+				if (fileLoggerPrv != null) {
+					builder.Services.AddSingleton<ILoggerProvider, FileLoggerProvider>(
+						(srvPrv) => {
+							return fileLoggerPrv;
+						}
+					);
 				}
-			);
+			}
 
 			return builder;
 		}

--- a/src/NReco.Logging.File/FileLoggerExtensions.cs
+++ b/src/NReco.Logging.File/FileLoggerExtensions.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -76,7 +77,7 @@ namespace NReco.Logging.File {
 			builder.Services.AddSingleton<ILoggerProvider, FileLoggerProvider>(
 				(srvPrv) => {
 					IConfigurationSection loggingSection = srvPrv.GetRequiredService<IConfiguration>().GetSection("Logging");
-					return CreateFromConfiguration(loggingSection, configure);
+					return CreateFromConfiguration(loggingSection, configure) ?? NullLoggerProvider.Instance;
 				}
 			);
 

--- a/src/NReco.Logging.File/FileLoggerExtensions.cs
+++ b/src/NReco.Logging.File/FileLoggerExtensions.cs
@@ -74,7 +74,7 @@ namespace NReco.Logging.File {
 		/// </summary>
 		/// <remarks>File logger is not added if "File" section is not present or it doesn't contain "Path" property.</remarks>
 		public static ILoggingBuilder AddFile(this ILoggingBuilder builder, Action<FileLoggerOptions> configure = null) {
-			builder.Services.AddSingleton<ILoggerProvider, FileLoggerProvider>(
+			builder.Services.AddSingleton<ILoggerProvider>(
 				(srvPrv) => {
 					IConfigurationSection loggingSection = srvPrv.GetRequiredService<IConfiguration>().GetSection("Logging");
 					return CreateFromConfiguration(loggingSection, configure) ?? NullLoggerProvider.Instance;

--- a/src/NReco.Logging.File/FileLoggerExtensions.cs
+++ b/src/NReco.Logging.File/FileLoggerExtensions.cs
@@ -69,6 +69,21 @@ namespace NReco.Logging.File {
 		}
 
 		/// <summary>
+		/// Adds a file logger using the standard Logging configuration.
+		/// </summary>
+		/// <remarks>File logger is not added if "File" section is not present or it doesn't contain "Path" property.</remarks>
+		public static ILoggingBuilder AddFile(this ILoggingBuilder builder, Action<FileLoggerOptions> configure = null) {
+			builder.Services.AddSingleton<ILoggerProvider, FileLoggerProvider>(
+				(srvPrv) => {
+					IConfigurationSection loggingSection = srvPrv.GetRequiredService<IConfiguration>().GetSection("Logging");
+					return CreateFromConfiguration(loggingSection, configure);
+				}
+			);
+
+			return builder;
+		}
+
+		/// <summary>
 		/// Adds a file logger.
 		/// </summary>
 		/// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>


### PR DESCRIPTION
For situations where configuration is under the default "Logging" section. Also accepts an optional configure options action.

Usage: `loggingBuilder.AddFile()`