### PR TITLE
Explicitly specifying FileShare.Read attribute when opening log stream

### DIFF
--- a/src/NReco.Logging.File/FileLoggerProvider.cs
+++ b/src/NReco.Logging.File/FileLoggerProvider.cs
@@ -217,7 +217,7 @@ namespace NReco.Logging.File {
 				// so there is no need for a "manual" check first.
 				fileInfo.Directory.Create();
 
-				LogFileStream = new FileStream(LogFileName, FileMode.OpenOrCreate, FileAccess.Write);
+				LogFileStream = new FileStream(LogFileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
 				if (append) {
 					LogFileStream.Seek(0, SeekOrigin.End);
 				} else {


### PR DESCRIPTION
Using the library on iPhone (Xamarin) it appears, that the mention in #65
>FileShare is not specified but by default it is FileShare.Read which allows other processes to open the file for 'read'.

is not true for iPhone. When opening the file for read, which is currently in use by `FileLogger` it throws the sharing violation. With this pull request it does not.
I believe that this PR does not break anything else as FileShare.Read should be default option in other than iOS implementation.