### PR TITLE
Reduce heap allocation of the default log message formatting logic in the FileLogger.Log

### DIFF
--- a/src/NReco.Logging.File/Extensions/DateTimeExtensions.cs
+++ b/src/NReco.Logging.File/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+
+#nullable enable
+
+namespace NReco.Logging.File.Extensions {
+	public static class DateTimeExtensions {
+		public static bool TryFormatO(this DateTime dateTime, Span<char> destination, out int charsWritten) {
+			const int BaseCharCountInFormatO = 27;
+
+			int charsRequired = BaseCharCountInFormatO;
+			var kind = dateTime.Kind;
+			var offset = TimeZoneInfo.Local.GetUtcOffset(dateTime);
+			if (kind == DateTimeKind.Local) {
+				charsRequired += 6;
+			}
+			else if (kind == DateTimeKind.Utc) {
+				charsRequired++;
+			}
+
+			if (destination.Length < charsRequired) {
+				charsWritten = 0;
+				return false;
+			}
+
+			charsWritten = charsRequired;
+
+			var year = (uint)dateTime.Year;
+			var month = (uint)dateTime.Month;
+			var day = (uint)dateTime.Day;
+			var hour = (uint)dateTime.Hour;
+			var minute = (uint)dateTime.Minute;
+			var second = (uint)dateTime.Second;
+			var tick = (uint)(dateTime.Ticks - (dateTime.Ticks / TimeSpan.TicksPerSecond * TimeSpan.TicksPerSecond));
+
+			year.WriteDigits(destination, 4);
+			destination[4] = '-';
+			month.WriteDigits(destination.Slice(5), 2);
+			destination[7] = '-';
+			day.WriteDigits(destination.Slice(8), 2);
+			destination[10] = 'T';
+			hour.WriteDigits(destination.Slice(11), 2);
+			destination[13] = ':';
+			minute.WriteDigits(destination.Slice(14), 2);
+			destination[16] = ':';
+			second.WriteDigits(destination.Slice(17), 2);
+			destination[19] = '.';
+			tick.WriteDigits(destination.Slice(20), 7);
+
+			if (kind == DateTimeKind.Local) {
+				var offsetTotalMinutes = (int)(offset.Ticks / TimeSpan.TicksPerMinute);
+
+				var sign = '+';
+				if (offsetTotalMinutes < 0) {
+					sign = '-';
+					offsetTotalMinutes = -offsetTotalMinutes;
+				}
+
+				var offsetHours = Math.DivRem(offsetTotalMinutes, 60, out var offsetMinutes);
+
+				destination[27] = sign;
+				((uint)offsetHours).WriteDigits(destination.Slice(28), 2);
+				destination[30] = ':';
+				((uint)offsetMinutes).WriteDigits(destination.Slice(31), 2);
+			}
+			else if (kind == DateTimeKind.Utc) {
+				destination[27] = 'Z';
+			}
+
+			return true;
+		}
+	}
+}

--- a/src/NReco.Logging.File/Extensions/IntExtensions.cs
+++ b/src/NReco.Logging.File/Extensions/IntExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+#nullable enable
+
+namespace NReco.Logging.File.Extensions {
+	public static class IntExtensions {
+		public static int GetFormattedLength(this int value) {
+			return value == 0 ? 1 : (int)Math.Floor(Math.Log10(Math.Abs((double)value))) + (value > 0 ? 1 : 2);
+		}
+
+		public static bool TryFormat(this int value, Span<char> destination, out int charsWritten) {
+			charsWritten = value.GetFormattedLength();
+			if (destination.Length < charsWritten) {
+				charsWritten = 0;
+				return false;
+			}
+
+			var dst = destination.Slice(0, charsWritten);
+
+			if (value < 0) {
+				dst[0] = '-';
+				dst = dst.Slice(1);
+			}
+
+			((uint)Math.Abs((long)value)).WriteDigits(dst, dst.Length);
+			return true;
+		}
+
+		internal static void WriteDigits(this uint value, Span<char> destination, int count) {
+			for (var cur = count - 1; cur > 0; cur--) {
+				uint temp = '0' + value;
+				value /= 10;
+				destination[cur] = (char)(temp - (value * 10));
+			}
+
+			destination[0] = (char)('0' + value);
+		}
+	}
+}

--- a/src/NReco.Logging.File/Extensions/IntExtensions.cs
+++ b/src/NReco.Logging.File/Extensions/IntExtensions.cs
@@ -8,6 +8,7 @@ namespace NReco.Logging.File.Extensions {
 			return value == 0 ? 1 : (int)Math.Floor(Math.Log10(Math.Abs((double)value))) + (value > 0 ? 1 : 2);
 		}
 
+#if NETSTANDARD2_0
 		public static bool TryFormat(this int value, Span<char> destination, out int charsWritten) {
 			charsWritten = value.GetFormattedLength();
 			if (destination.Length < charsWritten) {
@@ -35,5 +36,6 @@ namespace NReco.Logging.File.Extensions {
 
 			destination[0] = (char)('0' + value);
 		}
+#endif
 	}
 }

--- a/src/NReco.Logging.File/LogMessage.cs
+++ b/src/NReco.Logging.File/LogMessage.cs
@@ -3,7 +3,7 @@
  * NReco file logging provider (https://github.com/nreco/logging)
  * Copyright 2017 Vitaliy Fedorchenko
  * Distributed under the MIT license
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,13 +13,11 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.Extensions.Logging;
 
 namespace NReco.Logging.File {
 
-	public struct LogMessage {
+	public readonly struct LogMessage {
 		public readonly string LogName;
 		public readonly string Message;
 		public readonly LogLevel LogLevel;

--- a/src/NReco.Logging.File/NReco.Logging.File.csproj
+++ b/src/NReco.Logging.File/NReco.Logging.File.csproj
@@ -83,7 +83,19 @@ Version 1.0.4 changes:
     <AssemblyOriginatorKeyFile>NReco.Logging.File.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.*" />

--- a/src/NReco.Logging.File/NReco.Logging.File.csproj
+++ b/src/NReco.Logging.File/NReco.Logging.File.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <Description>Lightweight file logging provider implementation for NET6 / NET8+ / .NET Core without dependencies on logging frameworks.
-	
+
 How to use:
 
 using NReco.Logging.File;
 
-services.AddLogging(loggingBuilder => {
+services.AddLogging(loggingBuilder =&gt; {
 	loggingBuilder.AddFile("app.log", append:true);
 });
 
@@ -19,6 +19,7 @@ More details and examples: https://github.com/nreco/logging
     <VersionPrefix>1.2.1</VersionPrefix>
     <Authors>Vitalii Fedorchenko</Authors>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>NReco.Logging.File</AssemblyName>
     <PackageId>NReco.Logging.File</PackageId>
@@ -27,10 +28,10 @@ More details and examples: https://github.com/nreco/logging
     <PackageProjectUrl>https://github.com/nreco/logging</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/nreco/logging/master/LICENSE</PackageLicenseUrl>
 	<PackageReleaseNotes>How to use: https://github.com/nreco/logging
-	
+
 Version 1.2.1 changes:
  - Added different rolling name conventions #66 (unix-style is supported with 'Descending' convention)
-	
+
 Version 1.2.0 changes:
  - NReco's FileLoggerExtensions should NOT be in the Microsoft.Extensions.Logging namespace #61
  - Added net6 and net8 builds to reference appropriate Microsoft.Logging.Extensions versions
@@ -65,7 +66,7 @@ Version 1.1.0 changes:
 Version 1.0.5 changes:
  - log file folder is created automatically if not exists
  - environment variables are expanded in the file path
-	
+
 Version 1.0.4 changes:
  - added "File" provider alias for MVC Core 2 filtering rules
  - added 'rolling file' behaviour controlled with new FileLoggerProvider properties (FileSizeLimitBytes and MaxRollingFiles)</PackageReleaseNotes>
@@ -81,23 +82,11 @@ Version 1.0.4 changes:
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>NReco.Logging.File.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.*" /> 
-  </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.*" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.*" />  
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.*" />
   </ItemGroup>
-    
+
 </Project>

--- a/src/NReco.Logging.File/ValueStringBuilder.cs
+++ b/src/NReco.Logging.File/ValueStringBuilder.cs
@@ -1,0 +1,277 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#nullable enable
+
+namespace System.Text {
+	internal ref partial struct ValueStringBuilder {
+		private char[]? _arrayToReturnToPool;
+		private Span<char> _chars;
+		private int _pos;
+
+		public ValueStringBuilder(Span<char> initialBuffer) {
+			_arrayToReturnToPool = null;
+			_chars = initialBuffer;
+			_pos = 0;
+		}
+
+		public ValueStringBuilder(int initialCapacity) {
+			_arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+			_chars = _arrayToReturnToPool;
+			_pos = 0;
+		}
+
+		public int Length {
+			get => _pos;
+			set {
+				Debug.Assert(value >= 0);
+				Debug.Assert(value <= _chars.Length);
+				_pos = value;
+			}
+		}
+
+		public int Capacity => _chars.Length;
+
+		public void EnsureCapacity(int capacity) {
+			// This is not expected to be called this with negative capacity
+			Debug.Assert(capacity >= 0);
+
+			// If the caller has a bug and calls this with negative capacity, make sure to call Grow to throw an exception.
+			if ((uint)capacity > (uint)_chars.Length)
+				Grow(capacity - _pos);
+		}
+
+		/// <summary>
+		/// Get a pinnable reference to the builder.
+		/// Does not ensure there is a null char after <see cref="Length"/>
+		/// This overload is pattern matched in the C# 7.3+ compiler so you can omit
+		/// the explicit method call, and write eg "fixed (char* c = builder)"
+		/// </summary>
+		public ref char GetPinnableReference() {
+			return ref MemoryMarshal.GetReference(_chars);
+		}
+
+		/// <summary>
+		/// Get a pinnable reference to the builder.
+		/// </summary>
+		/// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+		public ref char GetPinnableReference(bool terminate) {
+			if (terminate) {
+				EnsureCapacity(Length + 1);
+				_chars[Length] = '\0';
+			}
+			return ref MemoryMarshal.GetReference(_chars);
+		}
+
+		public ref char this[int index] {
+			get {
+				Debug.Assert(index < _pos);
+				return ref _chars[index];
+			}
+		}
+
+		public override string ToString() {
+			string s = _chars.Slice(0, _pos).ToString();
+			Dispose();
+			return s;
+		}
+
+		/// <summary>Returns the underlying storage of the builder.</summary>
+		public Span<char> RawChars => _chars;
+
+		/// <summary>Returns a span representing the remaining space available in the underlying storage of the builder.</summary>
+		public Span<char> RemainingRawChars => _chars.Slice(_pos);
+
+		/// <summary>
+		/// Returns a span around the contents of the builder.
+		/// </summary>
+		/// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+		public ReadOnlySpan<char> AsSpan(bool terminate) {
+			if (terminate) {
+				EnsureCapacity(Length + 1);
+				_chars[Length] = '\0';
+			}
+			return _chars.Slice(0, _pos);
+		}
+
+		public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+		public ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
+		public ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
+
+		public bool TryCopyTo(Span<char> destination, out int charsWritten) {
+			if (_chars.Slice(0, _pos).TryCopyTo(destination)) {
+				charsWritten = _pos;
+				Dispose();
+				return true;
+			}
+			else {
+				charsWritten = 0;
+				Dispose();
+				return false;
+			}
+		}
+
+		public void Insert(int index, char value, int count) {
+			if (_pos > _chars.Length - count) {
+				Grow(count);
+			}
+
+			int remaining = _pos - index;
+			_chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+			_chars.Slice(index, count).Fill(value);
+			_pos += count;
+		}
+
+		public void Insert(int index, string? s) {
+			if (s == null) {
+				return;
+			}
+
+			int count = s.Length;
+
+			if (_pos > (_chars.Length - count)) {
+				Grow(count);
+			}
+
+			int remaining = _pos - index;
+			_chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+			s
+#if !NET
+				.AsSpan()
+#endif
+				.CopyTo(_chars.Slice(index));
+			_pos += count;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public void Append(char c) {
+			int pos = _pos;
+			Span<char> chars = _chars;
+			if ((uint)pos < (uint)chars.Length) {
+				chars[pos] = c;
+				_pos = pos + 1;
+			}
+			else {
+				GrowAndAppend(c);
+			}
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public void Append(string? s) {
+			if (s == null) {
+				return;
+			}
+
+			int pos = _pos;
+			if (s.Length == 1 && (uint)pos < (uint)_chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
+			{
+				_chars[pos] = s[0];
+				_pos = pos + 1;
+			}
+			else {
+				AppendSlow(s);
+			}
+		}
+
+		private void AppendSlow(string s) {
+			int pos = _pos;
+			if (pos > _chars.Length - s.Length) {
+				Grow(s.Length);
+			}
+
+			s
+#if !NET
+				.AsSpan()
+#endif
+				.CopyTo(_chars.Slice(pos));
+			_pos += s.Length;
+		}
+
+		public void Append(char c, int count) {
+			if (_pos > _chars.Length - count) {
+				Grow(count);
+			}
+
+			Span<char> dst = _chars.Slice(_pos, count);
+			for (int i = 0; i < dst.Length; i++) {
+				dst[i] = c;
+			}
+			_pos += count;
+		}
+
+		public void Append(scoped ReadOnlySpan<char> value) {
+			int pos = _pos;
+			if (pos > _chars.Length - value.Length) {
+				Grow(value.Length);
+			}
+
+			value.CopyTo(_chars.Slice(_pos));
+			_pos += value.Length;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Span<char> AppendSpan(int length) {
+			int origPos = _pos;
+			if (origPos > _chars.Length - length) {
+				Grow(length);
+			}
+
+			_pos = origPos + length;
+			return _chars.Slice(origPos, length);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private void GrowAndAppend(char c) {
+			Grow(1);
+			Append(c);
+		}
+
+		/// <summary>
+		/// Resize the internal buffer either by doubling current buffer size or
+		/// by adding <paramref name="additionalCapacityBeyondPos"/> to
+		/// <see cref="_pos"/> whichever is greater.
+		/// </summary>
+		/// <param name="additionalCapacityBeyondPos">
+		/// Number of chars requested beyond current position.
+		/// </param>
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private void Grow(int additionalCapacityBeyondPos) {
+			Debug.Assert(additionalCapacityBeyondPos > 0);
+			Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
+
+			const uint ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
+
+			// Increase to at least the required size (_pos + additionalCapacityBeyondPos), but try
+			// to double the size if possible, bounding the doubling to not go beyond the max array length.
+			int newCapacity = (int)Math.Max(
+				(uint)(_pos + additionalCapacityBeyondPos),
+				Math.Min((uint)_chars.Length * 2, ArrayMaxLength));
+
+			// Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative.
+			// This could also go negative if the actual required length wraps around.
+			char[] poolArray = ArrayPool<char>.Shared.Rent(newCapacity);
+
+			_chars.Slice(0, _pos).CopyTo(poolArray);
+
+			char[]? toReturn = _arrayToReturnToPool;
+			_chars = _arrayToReturnToPool = poolArray;
+			if (toReturn != null) {
+				ArrayPool<char>.Shared.Return(toReturn);
+			}
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public void Dispose() {
+			char[]? toReturn = _arrayToReturnToPool;
+			this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+			if (toReturn != null) {
+				ArrayPool<char>.Shared.Return(toReturn);
+			}
+		}
+	}
+}

--- a/test/NReco.Logging.Tests/DateTimeExtensionsTests.cs
+++ b/test/NReco.Logging.Tests/DateTimeExtensionsTests.cs
@@ -1,0 +1,116 @@
+﻿using NReco.Logging.File.Extensions;
+using System;
+using Xunit;
+
+namespace NReco.Logging.Tests {
+	public class DateTimeExtensionsTests {
+
+		[Fact]
+		public void GetFormattedLengthOfDateTimeNow() {
+			var result = DateTime.Now.GetFormattedLength();
+
+			Assert.Equal(33, result);
+		}
+
+		[Fact]
+		public void GetFormattedLengthOfDateTimeUtcNow() {
+			var result = DateTime.UtcNow.GetFormattedLength();
+
+			Assert.Equal(28, result);
+		}
+
+		[Fact]
+		public void GetFormattedLengthOfDateTimeKindUnspecified() {
+			var testValue = new DateTime(2024, 01, 01, 01, 01, 01, DateTimeKind.Unspecified);
+
+			var result = testValue.GetFormattedLength();
+
+			Assert.Equal(27, result);
+		}
+
+		[Fact]
+		public void GetFormattedLengthOfDefaultDateTime() {
+			var result = default(DateTime).GetFormattedLength();
+
+			Assert.Equal(27, result);
+		}
+
+		[Fact]
+		public void TryFormatLocal() {
+			var testValue = DateTime.Now;
+			var expected = testValue.ToString("O");
+
+			Span<char> span = stackalloc char[33];
+			var result = testValue.TryFormatO(span, out var charsWritten);
+
+			Assert.True(result);
+			Assert.Equal(33, charsWritten);
+			Assert.True(span.SequenceEqual(expected.AsSpan()));
+		}
+
+		[Fact]
+		public void TryFormatUtc() {
+			var testValue = DateTime.UtcNow;
+			var expected = testValue.ToString("O") + "\0\0\0\0\0";
+
+			Span<char> span = stackalloc char[33];
+			var result = testValue.TryFormatO(span, out var charsWritten);
+
+			Assert.True(result);
+			Assert.Equal(28, charsWritten);
+			Assert.True(span.SequenceEqual(expected.AsSpan()));
+		}
+
+		[Fact]
+		public void TryFormatUnspecified() {
+			var testValue = new DateTime(2024, 1, 1, 1, 1, 1, DateTimeKind.Unspecified);
+			var expected = testValue.ToString("O") + "\0\0\0\0\0\0";
+
+			Span<char> span = stackalloc char[33];
+			var result = testValue.TryFormatO(span, out var charsWritten);
+
+			Assert.True(result);
+			Assert.Equal(27, charsWritten);
+			Assert.True(span.SequenceEqual(expected.AsSpan()));
+		}
+
+		[Fact]
+		public void TryFormatDefault() {
+			var testValue = default(DateTime);
+			var expected = testValue.ToString("O") + "\0\0\0\0\0\0";
+
+			Span<char> span = stackalloc char[33];
+			var result = testValue.TryFormatO(span, out var charsWritten);
+
+			Assert.True(result);
+			Assert.Equal(27, charsWritten);
+			Assert.True(span.SequenceEqual(expected.AsSpan()));
+		}
+
+		[Fact]
+		public void TryFormatMaxValue() {
+			var testValue = DateTime.MaxValue;
+			var expected = testValue.ToString("O") + "\0\0\0\0\0\0";
+
+			Span<char> span = stackalloc char[33];
+			var result = testValue.TryFormatO(span, out var charsWritten);
+
+			Assert.True(result);
+			Assert.Equal(27, charsWritten);
+			Assert.True(span.SequenceEqual(expected.AsSpan()));
+		}
+
+		[Fact]
+		public void TryFormatIntoTooShortSpan() {
+			var testValue = DateTime.Now;
+			ReadOnlySpan<char> expected = stackalloc char[25];
+
+			Span<char> span = stackalloc char[25];
+			var result = testValue.TryFormatO(span, out var charsWritten);
+
+			Assert.False(result);
+			Assert.Equal(0, charsWritten);
+			Assert.True(span.SequenceEqual(expected));
+		}
+	}
+}

--- a/test/NReco.Logging.Tests/DateTimeExtensionsTests.cs
+++ b/test/NReco.Logging.Tests/DateTimeExtensionsTests.cs
@@ -21,9 +21,7 @@ namespace NReco.Logging.Tests {
 
 		[Fact]
 		public void GetFormattedLengthOfDateTimeKindUnspecified() {
-			var testValue = new DateTime(2024, 01, 01, 01, 01, 01, DateTimeKind.Unspecified);
-
-			var result = testValue.GetFormattedLength();
+			var result = new DateTime(2024, 01, 01, 01, 01, 01, DateTimeKind.Unspecified).GetFormattedLength();
 
 			Assert.Equal(27, result);
 		}
@@ -38,7 +36,7 @@ namespace NReco.Logging.Tests {
 		[Fact]
 		public void TryFormatLocal() {
 			var testValue = DateTime.Now;
-			var expected = testValue.ToString("O");
+			var expected = $"{testValue:O}";
 
 			Span<char> span = stackalloc char[33];
 			var result = testValue.TryFormatO(span, out var charsWritten);
@@ -51,7 +49,7 @@ namespace NReco.Logging.Tests {
 		[Fact]
 		public void TryFormatUtc() {
 			var testValue = DateTime.UtcNow;
-			var expected = testValue.ToString("O") + "\0\0\0\0\0";
+			var expected = $"{testValue:O}\0\0\0\0\0";
 
 			Span<char> span = stackalloc char[33];
 			var result = testValue.TryFormatO(span, out var charsWritten);
@@ -64,7 +62,7 @@ namespace NReco.Logging.Tests {
 		[Fact]
 		public void TryFormatUnspecified() {
 			var testValue = new DateTime(2024, 1, 1, 1, 1, 1, DateTimeKind.Unspecified);
-			var expected = testValue.ToString("O") + "\0\0\0\0\0\0";
+			var expected = $"{testValue:O}\0\0\0\0\0\0";
 
 			Span<char> span = stackalloc char[33];
 			var result = testValue.TryFormatO(span, out var charsWritten);
@@ -77,7 +75,7 @@ namespace NReco.Logging.Tests {
 		[Fact]
 		public void TryFormatDefault() {
 			var testValue = default(DateTime);
-			var expected = testValue.ToString("O") + "\0\0\0\0\0\0";
+			var expected = $"{testValue:O}\0\0\0\0\0\0";
 
 			Span<char> span = stackalloc char[33];
 			var result = testValue.TryFormatO(span, out var charsWritten);
@@ -90,7 +88,7 @@ namespace NReco.Logging.Tests {
 		[Fact]
 		public void TryFormatMaxValue() {
 			var testValue = DateTime.MaxValue;
-			var expected = testValue.ToString("O") + "\0\0\0\0\0\0";
+			var expected = $"{testValue:O}\0\0\0\0\0\0";
 
 			Span<char> span = stackalloc char[33];
 			var result = testValue.TryFormatO(span, out var charsWritten);

--- a/test/NReco.Logging.Tests/FileProviderTests.cs
+++ b/test/NReco.Logging.Tests/FileProviderTests.cs
@@ -73,7 +73,7 @@ namespace NReco.Logging.Tests
 				factory.Dispose();
 
 				Assert.Equal(3, System.IO.File.ReadAllLines(tmpFile).Length);
-				
+
 			} finally {
 				System.IO.File.Delete(tmpFile);
 			}
@@ -225,7 +225,7 @@ namespace NReco.Logging.Tests
 					logger.LogInformation("TEST 0123456789");
 					if (i % 50 == 0) {
 						System.Threading.Thread.Sleep(20); // give some time for log writer to handle the queue
-					}	
+					}
 				}
 				factory.Dispose();
 				Assert.Equal(5, Directory.GetFiles(tmpFileDir, "test*.log").Length);
@@ -293,14 +293,14 @@ namespace NReco.Logging.Tests
 		[Fact]
 		public void CreateDirectoryAutomatically()
 		{
-			
+
 			var tmpFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "testfile.log");
 			try
 			{
 				var factory = new LoggerFactory();
-				
+
 				factory.AddProvider(new FileLoggerProvider(tmpFile, new FileLoggerOptions()));
-				
+
 				var logger = factory.CreateLogger("TEST");
 				logger.LogInformation("Line1");
 				factory.Dispose();
@@ -363,7 +363,7 @@ namespace NReco.Logging.Tests
 					if (i > 0 && i % 5 == 0)
 						Thread.Sleep(1000); // log writer works in another thread. Let him to process log messages in queue.
 					logger.LogInformation("Line" + (i + 1).ToString());
-					
+
 				}
 				factory.Dispose();
 
@@ -417,19 +417,19 @@ namespace NReco.Logging.Tests
 				});
 
 				var errorHandled = false;
-				var factory2 = new LoggerFactory();
-				toDispose.Add(factory2);
+				var factory3 = new LoggerFactory();
+				toDispose.Add(factory3);
 				var altLogFileName = Path.Combine(tmpDir, "testfile_after_err.log");
-				factory2.AddProvider(new FileLoggerProvider(logFileName, new FileLoggerOptions() {
+				factory3.AddProvider(new FileLoggerProvider(logFileName, new FileLoggerOptions() {
 					HandleFileError = (err) => {
 						errorHandled = true;
 						err.UseNewLogFileName(altLogFileName);
 					}
 				}));
-				var logger2 = factory2.CreateLogger("TEST");
-				writeSomethingToLogger(logger2, 15);
+				var logger3 = factory3.CreateLogger("TEST");
+				writeSomethingToLogger(logger3, 15);
 				Assert.True(errorHandled);
-				factory2.Dispose();
+				factory3.Dispose();
 				// ensure that alt file name was used
 				var altLogFileInfo = new FileInfo(altLogFileName);
 				Assert.True(altLogFileInfo.Exists);
@@ -471,7 +471,7 @@ namespace NReco.Logging.Tests
 			var logFileWr = fileLogPrv.GetType()
 					.GetField("fWriter", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
 					.GetValue(fileLogPrv);
-			// close file handler, this will cause an exception inside FileLoggerProvider.ProcessQueue 
+			// close file handler, this will cause an exception inside FileLoggerProvider.ProcessQueue
 			var logFileStream = (Stream)logFileWr.GetType()
 				.GetField("LogFileStream", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
 				.GetValue(logFileWr);
@@ -496,7 +496,7 @@ namespace NReco.Logging.Tests
 			var logFileName = Path.Combine(tmpDir, "testfile.log");
 			var factory = new LoggerFactory();
 			try {
-				factory.AddProvider(new FileLoggerProvider(logFileName, new FileLoggerOptions() { 
+				factory.AddProvider(new FileLoggerProvider(logFileName, new FileLoggerOptions() {
 					FilterLogEntry = (logEntry) => {
 						return logEntry.LogName == "TEST";
 					}
@@ -515,7 +515,7 @@ namespace NReco.Logging.Tests
 			} finally {
 				CleanupTempDir(tmpDir, new[] { factory });
 			}
-		} 		
+		}
 
 	}
 }

--- a/test/NReco.Logging.Tests/IntExtensionsTests.cs
+++ b/test/NReco.Logging.Tests/IntExtensionsTests.cs
@@ -1,0 +1,77 @@
+﻿using NReco.Logging.File.Extensions;
+using System;
+using Xunit;
+
+namespace NReco.Logging.Tests {
+	public class IntExtensionsTests {
+
+		[Fact]
+		public void GetFormattedLengthOfZero() {
+			var result = 0.GetFormattedLength();
+
+			Assert.Equal(1, result);
+		}
+
+		[Fact]
+		public void GetFormattedLengthOfMinValue() {
+			var result = int.MinValue.GetFormattedLength();
+
+			Assert.Equal(11, result);
+		}
+
+		[Fact]
+		public void GetFormattedLengthOfMaxValue() {
+			var result = int.MaxValue.GetFormattedLength();
+
+			Assert.Equal(10, result);
+		}
+
+		[Fact]
+		public void TryFormatZero() {
+			const string expected = "0\0\0\0\0\0\0\0\0\0\0";
+
+			Span<char> span = stackalloc char[11];
+			var result = 0.TryFormat(span, out var charsWritten);
+
+			Assert.True(result);
+			Assert.Equal(1, charsWritten);
+			Assert.True(span.SequenceEqual(expected.AsSpan()));
+		}
+
+		[Fact]
+		public void TryFormatMinValue() {
+			const string expected = "-2147483648";
+
+			Span<char> span = stackalloc char[11];
+			var result = int.MinValue.TryFormat(span, out var charsWritten);
+
+			Assert.True(result);
+			Assert.Equal(11, charsWritten);
+			Assert.True(span.SequenceEqual(expected.AsSpan()));
+		}
+
+		[Fact]
+		public void TryFormatMaxValue() {
+			const string expected = "2147483647\0";
+
+			Span<char> span = stackalloc char[11];
+			var result = int.MaxValue.TryFormat(span, out var charsWritten);
+
+			Assert.True(result);
+			Assert.Equal(10, charsWritten);
+			Assert.True(span.SequenceEqual(expected.AsSpan()));
+		}
+
+		[Fact]
+		public void TryFormatIntoTooShortSpan() {
+			const string expected = "\0\0\0\0\0";
+
+			Span<char> span = stackalloc char[5];
+			var result = int.MaxValue.TryFormat(span, out var charsWritten);
+
+			Assert.False(result);
+			Assert.Equal(0, charsWritten);
+			Assert.True(span.SequenceEqual(expected.AsSpan()));
+		}
+	}
+}

--- a/test/NReco.Logging.Tests/NReco.Logging.Tests.csproj
+++ b/test/NReco.Logging.Tests/NReco.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>NReco.Logging.Tests</AssemblyName>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/NReco.Logging.Tests/NReco.Logging.Tests.csproj
+++ b/test/NReco.Logging.Tests/NReco.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net481</TargetFrameworks>
     <AssemblyName>NReco.Logging.Tests</AssemblyName>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
The purpose of this PR is to reduce allocations done by `FileLogger.Log()` at run time.

## Details
### Profiling
Here's a simple `Program.cs` that logs 10000 messages:
```csharp
using Microsoft.Extensions.Logging;
using NReco.Logging.File;

using var provider = new FileLoggerProvider("test.log");
var logger = new FileLogger("TestLogName", provider);

for (int i = 0; i < 10000; i++) {
	logger.Log(LogLevel.Information, "Test log message {number}", "1");
}
```

We can profile this program in Visual Studio with ".NET Object Allocation Tracking" enabled.

Here's how the profiling results look before the changes from this PR.
Note that for 10000 messages the code is allocating 40000 char arrays, ~30000 strings, 40000 `StringBuilder`s and boxes 10000 `EventId`s, all of those allocations consume memory which leads to more frequent GCs.
![image](https://github.com/user-attachments/assets/0751b545-d590-48da-9731-b1c0546e3e5b)

In contrast, here are the results with these changes.
No char arrays, no `StringBuilder`s, we no longer box `EventId`s and allocate one less string per log message.
![image](https://github.com/user-attachments/assets/dbeb8e17-c0f5-412a-b166-2a0dfc82489d)

### Benchmark
BenchmarkDotNet results:
```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4317/23H2/2023Update/SunValley3)
13th Gen Intel Core i9-13900K, 1 CPU, 32 logical and 24 physical cores
.NET SDK 8.0.403
  [Host]     : .NET 8.0.10 (8.0.1024.46610), X64 RyuJIT AVX2 [AttachedDebugger]
  DefaultJob : .NET 8.0.10 (8.0.1024.46610), X64 RyuJIT AVX2
```
| Method                  | Mean     | Ratio | RatioSD | Gen1   | Allocated | Alloc Ratio |
|------------------------ |---------:|------:|--------:|-------:|----------:|------------:|
| OriginalLoggerBenchmark | 401.7 ns |  1.00 |    0.03 | 0.0086 |     960 B |        1.00 |
| UpdatedLoggerBenchmark  | 390.9 ns |  0.97 |    0.02 |      - |     272 B |        0.28 |


### Expected outcome
These changes may prove useful in memory-constrained environments like docker containers, low-power devices (e.g. Raspberry), etc., as well as in high-thoughput scenarios where GC pressure is constantly high.

