### PR TITLE
Use MIT SPDX license identifier in Nuget metadata

### DIFF
--- a/src/NReco.Logging.File/NReco.Logging.File.csproj
+++ b/src/NReco.Logging.File/NReco.Logging.File.csproj
@@ -26,7 +26,7 @@ More details and examples: https://github.com/nreco/logging
     <PackageTags>log;file;logging;asp.net;file-logger;logging-provider;netstandard;netcore</PackageTags>
     <PackageIconUrl>https://www.nrecosite.com/img/nreco-logo-200.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/nreco/logging</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/nreco/logging/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<PackageReleaseNotes>How to use: https://github.com/nreco/logging
 
 Version 1.3.1 changes:


### PR DESCRIPTION
licenseUrl is deprecated in the nuget spec. Using an SPDX identifier for the license is the recommended approach.

https://learn.microsoft.com/en-us/nuget/reference/nuspec#licenseurl
https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file

This is of practical importance for downstream projects that use automatic tools to inspect and document licenses. This is the "licenses" element that dotnet-CycloneDX currently generates for NReco.Logging:

    "licenses": [
      {
        "license": {
          "name": "Unknown - See URL",
          "url": "https://raw.githubusercontent.com/nreco/logging/master/LICENSE"
        }
      }
    ]

With this commit it becomes simply:

    "licenses": [
      {
        "license": {
          "id": "MIT"
        }
      }
    ]