### PR TITLE
Implemented time-based file rolling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ obj/
 .vs
 *.nuget.targets
 *.lock.json
+.devcontainer.json
+.clad.json
+.ironClad.dockerfile

--- a/src/NReco.Logging.File/FileLoggerConfig.cs
+++ b/src/NReco.Logging.File/FileLoggerConfig.cs
@@ -13,6 +13,7 @@
 #endregion
 
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace NReco.Logging.File {
 
@@ -45,6 +46,12 @@ namespace NReco.Logging.File {
 		/// For example, if log file name is 'test.log' and max files = 3, logger will use: 'test.log', then 'test1.log', then 'test2.log' and then 'test.log' again (old content is removed).
 		/// </remarks>
 		public int MaxRollingFiles { get; set; } = 0;
+
+		/// <summary>
+		/// Determines max timespan of the one log file.
+		/// </summary>
+		/// See <see cref="FileSizeLimitBytes"/> on how this affects file names.
+		public TimeSpan	FileTimeSpanLimit { get; set; } = TimeSpan.Zero;
 
 		/// <summary>
 		/// Minimal logging level for the file logger.

--- a/src/NReco.Logging.File/FileLoggerExtensions.cs
+++ b/src/NReco.Logging.File/FileLoggerExtensions.cs
@@ -126,6 +126,7 @@ namespace NReco.Logging.File {
 			fileLoggerOptions.MinLevel = config.MinLevel;
 			fileLoggerOptions.FileSizeLimitBytes = config.FileSizeLimitBytes;
 			fileLoggerOptions.MaxRollingFiles = config.MaxRollingFiles;
+			fileLoggerOptions.FileTimeSpanLimit = config.FileTimeSpanLimit;
 
 			if (configure != null)
 				configure(fileLoggerOptions);

--- a/src/NReco.Logging.File/FileLoggerOptions.cs
+++ b/src/NReco.Logging.File/FileLoggerOptions.cs
@@ -35,6 +35,12 @@ namespace NReco.Logging.File {
 		public long FileSizeLimitBytes { get; set; } = 0;
 
 		/// <summary>
+		/// Determines max timespan of the one log file.
+		/// </summary>
+		/// See <see cref="FileSizeLimitBytes"/> on how this affects file names.
+		public TimeSpan FileTimeSpanLimit { get; set; } = TimeSpan.Zero;
+
+		/// <summary>
 		/// Determines max number of log files if <see cref="FileSizeLimitBytes"/> is specified.
 		/// </summary>
 		/// <remarks>If MaxRollingFiles is specified file logger will re-write previously created log files.

--- a/src/NReco.Logging.File/FileLoggerProvider.cs
+++ b/src/NReco.Logging.File/FileLoggerProvider.cs
@@ -39,6 +39,7 @@ namespace NReco.Logging.File {
 
 		private bool Append => Options.Append;
 		private long FileSizeLimitBytes => Options.FileSizeLimitBytes;
+		private TimeSpan FileTimeSpanLimit => Options.FileTimeSpanLimit;
 		private int MaxRollingFiles => Options.MaxRollingFiles;
 
 		public LogLevel MinLevel {
@@ -249,9 +250,12 @@ namespace NReco.Logging.File {
 			string GetNextFileLogName() {
 				var baseLogFileName = GetBaseLogFileName();
 				// if file does not exist or file size limit is not reached - do not add rolling file index
-				if (!System.IO.File.Exists(baseLogFileName) ||
-					FileLogPrv.FileSizeLimitBytes <= 0 ||
-					new System.IO.FileInfo(baseLogFileName).Length < FileLogPrv.FileSizeLimitBytes)
+				if (
+					!System.IO.File.Exists(baseLogFileName) 
+					|| (FileLogPrv.FileSizeLimitBytes <= 0 && FileLogPrv.FileTimeSpanLimit == TimeSpan.Zero) 
+					|| new FileInfo(baseLogFileName).Length < FileLogPrv.FileSizeLimitBytes
+					|| (DateTime.Now - System.IO.File.GetCreationTime(baseLogFileName)) <= FileLogPrv.FileTimeSpanLimit
+					)
 					return baseLogFileName;
 
 				switch (FileLogPrv.Options.RollingFilesConvention) {
@@ -303,15 +307,18 @@ namespace NReco.Logging.File {
 
 			void CheckForNewLogFile() {
 				bool openNewFile = false;
-				if (isMaxFileSizeThresholdReached() || isBaseFileNameChanged())
+				if (isMaxFileSizeThresholdReached() || isBaseFileNameChanged() || isMaxFileLifetimeThresholdReached())
 					openNewFile = true;
-
 				if (openNewFile) {
 					Close();
 					LogFileName = GetNextFileLogName();
 					OpenFile(false);
 				}
 
+				bool isMaxFileLifetimeThresholdReached() {
+					return FileLogPrv.FileTimeSpanLimit > TimeSpan.Zero && 
+						(DateTime.Now - System.IO.File.GetCreationTime(LogFileName)) > FileLogPrv.FileTimeSpanLimit;
+				}
 				bool isMaxFileSizeThresholdReached() {
 					return FileLogPrv.FileSizeLimitBytes > 0 && LogFileStream.Length > FileLogPrv.FileSizeLimitBytes;
 				}

--- a/test/NReco.Logging.Tests/FileProviderTests.cs
+++ b/test/NReco.Logging.Tests/FileProviderTests.cs
@@ -517,5 +517,43 @@ namespace NReco.Logging.Tests
 			}
 		}
 
+		[Fact]
+		public void RollFileOnTimeExpiration()
+		{
+			var tmpFileDir = Path.GetTempFileName();  // for test debug: "./"
+			System.IO.File.Delete(tmpFileDir);
+
+			Directory.CreateDirectory(tmpFileDir);
+			try {
+				var logFile = Path.Combine(tmpFileDir, "test.log");
+
+				LoggerFactory factory = null;
+				ILogger logger = null;
+				createFactoryAndTestLogger();
+
+				for (int i = 0; i < 5; i++) {
+					logger.LogInformation("TEST 0123456789");
+					Thread.Sleep(200);
+				}
+				factory.Dispose();
+				
+				Thread.Sleep(2000);
+				
+				Assert.Equal(5, Directory.GetFiles(tmpFileDir, "test*.log").Length);
+
+				void createFactoryAndTestLogger() {
+					factory = new LoggerFactory();
+					factory.AddProvider(new FileLoggerProvider(logFile, new FileLoggerOptions() {
+						FileTimeSpanLimit = TimeSpan.FromMilliseconds(100),
+						MaxRollingFiles = 5
+					}));
+					logger = factory.CreateLogger("TEST");
+				}
+
+			}
+			finally {
+				Directory.Delete(tmpFileDir, true);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Added the ability to roll the file forward based on its creation time. This allows for things like creating a new log file every 24 hours. 
Example:
```cs
factory.AddProvider(new FileLoggerProvider(logFile, new FileLoggerOptions() {
    FileTimeSpanLimit = TimeSpan.FromHours(24),
    MaxRollingFiles = 5
}));
```