### PR TITLE
Add optional logging scope support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,22 @@ Example of the configuration section in appsettings.json:
 		"Path": "app.log",
 		"Append": true,
 		"MinLevel": "Warning",  // min level for the file logger
+		"IncludeScopes": false,  // set to true to include logging scopes
 		"FileSizeLimitBytes": 0,  // use to activate rolling file behaviour
 		"MaxRollingFiles": 0  // use to specify max number of log files
 	}
 }
 ```
+
+## Logging scopes
+Logging scopes can be included in the default log entry format by setting `FileLoggerOptions.IncludeScopes` to `true` (the default is `false`):
+```csharp
+loggingBuilder.AddFile("app.log", fileLoggerOpts => {
+	fileLoggerOpts.IncludeScopes = true;
+});
+```
+Active scopes are written from outermost to innermost before the message, for example: `=> Request 123 => Processing order`.
+`IncludeScopes` applies only to the built-in formatter and does not change custom `FormatLogEntry` behavior.
 
 ## Rolling File
 This feature is activated with `FileLoggerOptions` properties: `FileSizeLimitBytes` and `MaxRollingFiles`. Lets assume that file logger is configured for "test.log":

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ loggingBuilder.AddFile("app.log", fileLoggerOpts => {
 });
 ```
 Active scopes are written from outermost to innermost before the message, for example: `=> Request 123 => Processing order`.
-`IncludeScopes` applies only to the built-in formatter and does not change custom `FormatLogEntry` behavior.
+A custom `FormatLogEntry` handler replaces this format entirely and can render scopes itself with `LogMessage.ScopeProvider`, which is also gated by `IncludeScopes`.
 
 ## Rolling File
 This feature is activated with `FileLoggerOptions` properties: `FileSizeLimitBytes` and `MaxRollingFiles`. Lets assume that file logger is configured for "test.log":

--- a/src/NReco.Logging.File/FileLogger.cs
+++ b/src/NReco.Logging.File/FileLogger.cs
@@ -50,16 +50,20 @@ namespace NReco.Logging.File {
 
 			string message = formatter(state, exception);
 
+			// IncludeScopes is the single opt-in for scope handling: when it is off, no formatter can reach scopes
+			// and the original formatting path does no scope work.
+			var scopeProvider = LoggerPrv.Options.IncludeScopes ? LoggerPrv.ScopeProvider : null;
+
 			if (LoggerPrv.Options.FilterLogEntry != null)
-				if (!LoggerPrv.Options.FilterLogEntry(new LogMessage(logName, logLevel, eventId, message, exception)))
+				if (!LoggerPrv.Options.FilterLogEntry(
+						new LogMessage(logName, logLevel, eventId, message, exception, scopeProvider)))
 					return;
 
 			if (LoggerPrv.FormatLogEntry != null) {
 				LoggerPrv.WriteEntry(LoggerPrv.FormatLogEntry(
-					new LogMessage(logName, logLevel, eventId, message, exception)));
+					new LogMessage(logName, logLevel, eventId, message, exception, scopeProvider)));
 			}
 			else {
-				// Pass no scope provider unless explicitly enabled so the original formatting path does no scope work.
 				LoggerPrv.WriteEntry( 
 					Format.StringLogEntryFormatter.Instance.LowAllocLogEntryFormat(
 						logName,
@@ -68,7 +72,7 @@ namespace NReco.Logging.File {
 						eventId,
 						message,
 						exception,
-						LoggerPrv.Options.IncludeScopes ? LoggerPrv.ScopeProvider : null));
+						scopeProvider));
 			}
 		}
 

--- a/src/NReco.Logging.File/FileLogger.cs
+++ b/src/NReco.Logging.File/FileLogger.cs
@@ -30,7 +30,8 @@ namespace NReco.Logging.File {
 			this.LoggerPrv = loggerPrv;
 		}
 		public IDisposable BeginScope<TState>(TState state) {
-			return null;
+			// Support BeginScope when FileLogger is used directly, matching ConsoleLogger.
+			return LoggerPrv.ScopeProvider?.Push(state);
 		}
 
 		public bool IsEnabled(LogLevel logLevel) {
@@ -58,6 +59,7 @@ namespace NReco.Logging.File {
 					new LogMessage(logName, logLevel, eventId, message, exception)));
 			}
 			else {
+				// Pass no scope provider unless explicitly enabled so the original formatting path does no scope work.
 				LoggerPrv.WriteEntry( 
 					Format.StringLogEntryFormatter.Instance.LowAllocLogEntryFormat(
 						logName,
@@ -65,7 +67,8 @@ namespace NReco.Logging.File {
 						logLevel,
 						eventId,
 						message,
-						exception));
+						exception,
+						LoggerPrv.Options.IncludeScopes ? LoggerPrv.ScopeProvider : null));
 			}
 		}
 

--- a/src/NReco.Logging.File/FileLoggerConfig.cs
+++ b/src/NReco.Logging.File/FileLoggerConfig.cs
@@ -50,6 +50,11 @@ namespace NReco.Logging.File {
 		/// Minimal logging level for the file logger.
 		/// </summary>
 		public LogLevel MinLevel { get; set; } = LogLevel.Trace;
+
+		/// <summary>
+		/// Gets or sets a value that indicates whether scopes are included. Defaults to false.
+		/// </summary>
+		public bool IncludeScopes { get; set; }
 	}
 
 }

--- a/src/NReco.Logging.File/FileLoggerExtensions.cs
+++ b/src/NReco.Logging.File/FileLoggerExtensions.cs
@@ -126,6 +126,7 @@ namespace NReco.Logging.File {
 			fileLoggerOptions.MinLevel = config.MinLevel;
 			fileLoggerOptions.FileSizeLimitBytes = config.FileSizeLimitBytes;
 			fileLoggerOptions.MaxRollingFiles = config.MaxRollingFiles;
+			fileLoggerOptions.IncludeScopes = config.IncludeScopes;
 
 			if (configure != null)
 				configure(fileLoggerOptions);

--- a/src/NReco.Logging.File/FileLoggerOptions.cs
+++ b/src/NReco.Logging.File/FileLoggerOptions.cs
@@ -48,6 +48,12 @@ namespace NReco.Logging.File {
 		public bool UseUtcTimestamp { get; set; }
 
 		/// <summary>
+		/// Gets or sets a value that indicates whether scopes are included. Defaults to false.
+		/// </summary>
+		/// <remarks>To preserve the existing <see cref="LogMessage"/> API, scopes are included only by the built-in formatter. Custom <see cref="FormatLogEntry"/> delegates do not receive scope data.</remarks>
+		public bool IncludeScopes { get; set; }
+
+		/// <summary>
 		/// Custom formatter for the log entry line. 
 		/// </summary>
 		public Func<LogMessage, string> FormatLogEntry { get; set; }

--- a/src/NReco.Logging.File/FileLoggerOptions.cs
+++ b/src/NReco.Logging.File/FileLoggerOptions.cs
@@ -50,7 +50,7 @@ namespace NReco.Logging.File {
 		/// <summary>
 		/// Gets or sets a value that indicates whether scopes are included. Defaults to false.
 		/// </summary>
-		/// <remarks>To preserve the existing <see cref="LogMessage"/> API, scopes are included only by the built-in formatter. Custom <see cref="FormatLogEntry"/> delegates do not receive scope data.</remarks>
+		/// <remarks>When enabled, scopes are written by the built-in formatter. A custom <see cref="FormatLogEntry"/> delegate replaces that format entirely and can render scopes itself via <see cref="LogMessage.ScopeProvider"/>, which is supplied only while this option is enabled.</remarks>
 		public bool IncludeScopes { get; set; }
 
 		/// <summary>

--- a/src/NReco.Logging.File/FileLoggerProvider.cs
+++ b/src/NReco.Logging.File/FileLoggerProvider.cs
@@ -25,7 +25,7 @@ namespace NReco.Logging.File {
 	/// Generic file logger provider.
 	/// </summary>
 	[ProviderAlias("File")]
-	public class FileLoggerProvider : ILoggerProvider {
+	public class FileLoggerProvider : ILoggerProvider, ISupportExternalScope {
 
 		private string LogFileName;
 
@@ -36,6 +36,7 @@ namespace NReco.Logging.File {
 		private readonly FileWriter fWriter;
 
 		internal FileLoggerOptions Options { get; private set; }
+		internal IExternalScopeProvider ScopeProvider { get; private set; }
 
 		private bool Append => Options.Append;
 		private long FileSizeLimitBytes => Options.FileSizeLimitBytes;
@@ -97,6 +98,12 @@ namespace NReco.Logging.File {
 
 		public ILogger CreateLogger(string categoryName) {
 			return loggers.GetOrAdd(categoryName, CreateLoggerImplementation);
+		}
+
+		/// <inheritdoc />
+		public void SetScopeProvider(IExternalScopeProvider scopeProvider) {
+			// Keep this centrally so existing loggers also observe a replacement, matching ConsoleLogger's defensive behavior.
+			ScopeProvider = scopeProvider;
 		}
 
 		public void Dispose() {

--- a/src/NReco.Logging.File/Format/StringLogEntryFormatter.cs
+++ b/src/NReco.Logging.File/Format/StringLogEntryFormatter.cs
@@ -14,6 +14,10 @@ namespace NReco.Logging.File.Format {
 	public class StringLogEntryFormatter {
 
 		internal static readonly StringLogEntryFormatter Instance = new StringLogEntryFormatter();
+		// ForEachScope cannot use the ref-struct ValueStringBuilder as callback state, so scopes use a reusable
+		// StringBuilder and are copied into the final ValueStringBuilder without creating an intermediate string.
+		[ThreadStatic]
+		private static StringBuilder cachedScopeBuilder;
 
 		public StringLogEntryFormatter() {
 		}
@@ -64,6 +68,34 @@ namespace NReco.Logging.File.Format {
 		/// This is a low-allocation optimized tab-separated log entry formatter that formats output identical to <see cref="StringBuilderLogEntryFormat"/>
 		/// </summary>
 		public string LowAllocLogEntryFormat(string logName, DateTime timeStamp, LogLevel logLevel, EventId eventId, string message, Exception exception) {
+			return LowAllocLogEntryFormatCore(logName, timeStamp, logLevel, eventId, message, exception, null);
+		}
+
+		internal string LowAllocLogEntryFormat(string logName, DateTime timeStamp, LogLevel logLevel, EventId eventId, string message, Exception exception, IExternalScopeProvider scopeProvider) {
+			if (scopeProvider == null) {
+				return LowAllocLogEntryFormatCore(logName, timeStamp, logLevel, eventId, message, exception, null);
+			}
+
+			var scopeBuilder = cachedScopeBuilder ?? new StringBuilder();
+			// Check the builder out of the cache so re-entrant logging on this thread cannot modify it.
+			cachedScopeBuilder = null;
+			try {
+				// Match SimpleConsoleFormatter: render active scopes outer-to-inner with "=>" separators.
+				scopeProvider.ForEachScope((scope, builder) => builder.Append(builder.Length == 0 ? "=> " : " => ").Append(scope), scopeBuilder);
+
+				return LowAllocLogEntryFormatCore(logName, timeStamp, logLevel, eventId, message, exception, scopeBuilder.Length > 0 ? scopeBuilder : null);
+			} finally {
+				scopeBuilder.Clear();
+				// Match ConsoleLogger's retention limit after an unusually large entry.
+				if (scopeBuilder.Capacity > 1024) {
+					scopeBuilder.Capacity = 1024;
+				}
+				// Return this builder only if a re-entrant log entry has not already replenished the cache.
+				cachedScopeBuilder ??= scopeBuilder;
+			}
+		}
+
+		private string LowAllocLogEntryFormatCore(string logName, DateTime timeStamp, LogLevel logLevel, EventId eventId, string message, Exception exception, StringBuilder scopeBuilder) {
 			const int MaxStackAllocatedBufferLength = 256;
 			var logMessageLength = CalculateLogMessageLength();
 			char[] charBuffer = null;
@@ -74,7 +106,8 @@ namespace NReco.Logging.File.Format {
 
 				// default formatting logic
 				using var logBuilder = new ValueStringBuilder(buffer);
-				if (!string.IsNullOrEmpty(message)) {
+				// Scopes are useful context even when an exception is logged without a message.
+				if (!string.IsNullOrEmpty(message) || scopeBuilder != null) {
 					timeStamp.TryFormatO(logBuilder.RemainingRawChars, out var charsWritten);
 					logBuilder.AppendSpan(charsWritten);
 					logBuilder.Append('\t');
@@ -90,7 +123,13 @@ namespace NReco.Logging.File.Format {
 						logBuilder.AppendSpan(charsWritten);
 					}
 					logBuilder.Append("]\t");
-					logBuilder.Append(message);
+					if (scopeBuilder != null) {
+						logBuilder.Append(scopeBuilder);
+						logBuilder.Append('\t');
+					}
+					if (!string.IsNullOrEmpty(message)) {
+						logBuilder.Append(message);
+					}
 				}
 
 				if (exception != null) {
@@ -114,6 +153,7 @@ namespace NReco.Logging.File.Format {
 					+ 3 /* "]\t[" */
 					+ (eventId.Name?.Length ?? eventId.Id.GetFormattedLength())
 					+ 2 /* "]\t" */
+					+ (scopeBuilder is null ? 0 : scopeBuilder.Length + 1) /* scopes + '\t' */
 					+ (message?.Length ?? 0);
 			}
 		}

--- a/src/NReco.Logging.File/Format/StringLogEntryFormatter.cs
+++ b/src/NReco.Logging.File/Format/StringLogEntryFormatter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.Logging;
@@ -14,10 +15,11 @@ namespace NReco.Logging.File.Format {
 	public class StringLogEntryFormatter {
 
 		internal static readonly StringLogEntryFormatter Instance = new StringLogEntryFormatter();
-		// ForEachScope cannot use the ref-struct ValueStringBuilder as callback state, so scopes use a reusable
-		// StringBuilder and are copied into the final ValueStringBuilder without creating an intermediate string.
+		// ForEachScope cannot use the ref-struct ValueStringBuilder as callback state, so scopes are collected into a
+		// reusable list first and appended to the final ValueStringBuilder directly. This list holds one entry per
+		// active scope, so its capacity stays as small as the scope nesting and never needs to be trimmed.
 		[ThreadStatic]
-		private static StringBuilder cachedScopeBuilder;
+		private static List<string> cachedScopes;
 
 		public StringLogEntryFormatter() {
 		}
@@ -76,26 +78,23 @@ namespace NReco.Logging.File.Format {
 				return LowAllocLogEntryFormatCore(logName, timeStamp, logLevel, eventId, message, exception, null);
 			}
 
-			var scopeBuilder = cachedScopeBuilder ?? new StringBuilder();
-			// Check the builder out of the cache so re-entrant logging on this thread cannot modify it.
-			cachedScopeBuilder = null;
+			var scopes = cachedScopes ?? new List<string>();
+			// Check the list out of the cache so re-entrant logging on this thread cannot modify it.
+			cachedScopes = null;
 			try {
-				// Match SimpleConsoleFormatter: render active scopes outer-to-inner with "=>" separators.
-				scopeProvider.ForEachScope((scope, builder) => builder.Append(builder.Length == 0 ? "=> " : " => ").Append(scope), scopeBuilder);
+				// Render each scope exactly once. Only the resulting strings are kept, so user scope objects are not
+				// held alive after the entry is formatted.
+				scopeProvider.ForEachScope(static (scope, state) => state.Add(scope?.ToString()), scopes);
 
-				return LowAllocLogEntryFormatCore(logName, timeStamp, logLevel, eventId, message, exception, scopeBuilder.Length > 0 ? scopeBuilder : null);
+				return LowAllocLogEntryFormatCore(logName, timeStamp, logLevel, eventId, message, exception, scopes.Count > 0 ? scopes : null);
 			} finally {
-				scopeBuilder.Clear();
-				// Match ConsoleLogger's retention limit after an unusually large entry.
-				if (scopeBuilder.Capacity > 1024) {
-					scopeBuilder.Capacity = 1024;
-				}
-				// Return this builder only if a re-entrant log entry has not already replenished the cache.
-				cachedScopeBuilder ??= scopeBuilder;
+				scopes.Clear();
+				// Return this list only if a re-entrant log entry has not already replenished the cache.
+				cachedScopes ??= scopes;
 			}
 		}
 
-		private string LowAllocLogEntryFormatCore(string logName, DateTime timeStamp, LogLevel logLevel, EventId eventId, string message, Exception exception, StringBuilder scopeBuilder) {
+		private string LowAllocLogEntryFormatCore(string logName, DateTime timeStamp, LogLevel logLevel, EventId eventId, string message, Exception exception, List<string> scopes) {
 			const int MaxStackAllocatedBufferLength = 256;
 			var logMessageLength = CalculateLogMessageLength();
 			char[] charBuffer = null;
@@ -107,7 +106,7 @@ namespace NReco.Logging.File.Format {
 				// default formatting logic
 				using var logBuilder = new ValueStringBuilder(buffer);
 				// Scopes are useful context even when an exception is logged without a message.
-				if (!string.IsNullOrEmpty(message) || scopeBuilder != null) {
+				if (!string.IsNullOrEmpty(message) || scopes != null) {
 					timeStamp.TryFormatO(logBuilder.RemainingRawChars, out var charsWritten);
 					logBuilder.AppendSpan(charsWritten);
 					logBuilder.Append('\t');
@@ -123,8 +122,12 @@ namespace NReco.Logging.File.Format {
 						logBuilder.AppendSpan(charsWritten);
 					}
 					logBuilder.Append("]\t");
-					if (scopeBuilder != null) {
-						logBuilder.Append(scopeBuilder);
+					if (scopes != null) {
+						// Match SimpleConsoleFormatter: render active scopes outer-to-inner with "=>" separators.
+						for (var i = 0; i < scopes.Count; i++) {
+							logBuilder.Append(i == 0 ? "=> " : " => ");
+							logBuilder.Append(scopes[i]);
+						}
 						logBuilder.Append('\t');
 					}
 					if (!string.IsNullOrEmpty(message)) {
@@ -153,8 +156,20 @@ namespace NReco.Logging.File.Format {
 					+ 3 /* "]\t[" */
 					+ (eventId.Name?.Length ?? eventId.Id.GetFormattedLength())
 					+ 2 /* "]\t" */
-					+ (scopeBuilder is null ? 0 : scopeBuilder.Length + 1) /* scopes + '\t' */
+					+ GetScopesLength()
 					+ (message?.Length ?? 0);
+			}
+
+			int GetScopesLength() {
+				if (scopes is null) {
+					return 0;
+				}
+
+				var scopesLength = 1 /* '\t' */;
+				for (var i = 0; i < scopes.Count; i++) {
+					scopesLength += (i == 0 ? 3 /* "=> " */ : 4 /* " => " */) + (scopes[i]?.Length ?? 0);
+				}
+				return scopesLength;
 			}
 		}
 

--- a/src/NReco.Logging.File/Format/ValueStringBuilder.cs
+++ b/src/NReco.Logging.File/Format/ValueStringBuilder.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 #nullable enable
 
@@ -213,6 +214,25 @@ namespace NReco.Logging.File.Format {
 
 			value.CopyTo(_chars.Slice(_pos));
 			_pos += value.Length;
+		}
+
+		public void Append(StringBuilder value) {
+			if (value == null || value.Length == 0) {
+				return;
+			}
+
+#if NETSTANDARD2_0
+			// netstandard2.0 lacks StringBuilder.CopyTo(Span<char>), so use a pooled array instead of allocating a string.
+			var buffer = ArrayPool<char>.Shared.Rent(value.Length);
+			try {
+				value.CopyTo(0, buffer, 0, value.Length);
+				Append(buffer.AsSpan(0, value.Length));
+			} finally {
+				ArrayPool<char>.Shared.Return(buffer);
+			}
+#else
+			value.CopyTo(0, AppendSpan(value.Length), value.Length);
+#endif
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/NReco.Logging.File/Format/ValueStringBuilder.cs
+++ b/src/NReco.Logging.File/Format/ValueStringBuilder.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 
 #nullable enable
 
@@ -214,25 +213,6 @@ namespace NReco.Logging.File.Format {
 
 			value.CopyTo(_chars.Slice(_pos));
 			_pos += value.Length;
-		}
-
-		public void Append(StringBuilder value) {
-			if (value == null || value.Length == 0) {
-				return;
-			}
-
-#if NETSTANDARD2_0
-			// netstandard2.0 lacks StringBuilder.CopyTo(Span<char>), so use a pooled array instead of allocating a string.
-			var buffer = ArrayPool<char>.Shared.Rent(value.Length);
-			try {
-				value.CopyTo(0, buffer, 0, value.Length);
-				Append(buffer.AsSpan(0, value.Length));
-			} finally {
-				ArrayPool<char>.Shared.Return(buffer);
-			}
-#else
-			value.CopyTo(0, AppendSpan(value.Length), value.Length);
-#endif
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/NReco.Logging.File/LogMessage.cs
+++ b/src/NReco.Logging.File/LogMessage.cs
@@ -24,12 +24,24 @@ namespace NReco.Logging.File {
 		public readonly EventId EventId;
 		public readonly Exception Exception;
 
-		internal LogMessage(string logName, LogLevel level, EventId eventId, string message, Exception ex) {
+		/// <summary>
+		/// Provides access to the active logging scopes, or <c>null</c> when scopes are unavailable.
+		/// </summary>
+		/// <remarks>
+		/// This is <c>null</c> unless <see cref="FileLoggerOptions.IncludeScopes"/> is enabled, so that option remains
+		/// the single opt-in for scope handling. It is also <c>null</c> if the logger provider was never given a scope
+		/// provider by a logging factory.
+		/// </remarks>
+		public readonly IExternalScopeProvider ScopeProvider;
+
+		internal LogMessage(string logName, LogLevel level, EventId eventId, string message, Exception ex,
+				IExternalScopeProvider scopeProvider = null) {
 			LogName = logName;
 			Message = message;
 			LogLevel = level;
 			EventId = eventId;
 			Exception = ex;
+			ScopeProvider = scopeProvider;
 		}
 
 	}

--- a/test/NReco.Logging.Tests/FileProviderTests.cs
+++ b/test/NReco.Logging.Tests/FileProviderTests.cs
@@ -517,5 +517,102 @@ namespace NReco.Logging.Tests
 			}
 		}
 
+		[Fact]
+		public void ScopesAreDisabledByDefault() {
+			var tmpFile = Path.GetTempFileName();
+			try {
+				using (var factory = new LoggerFactory()) {
+					factory.AddProvider(new FileLoggerProvider(tmpFile, false));
+					var logger = factory.CreateLogger("TEST");
+					using (logger.BeginScope("Scope")) {
+						logger.LogInformation("Message");
+					}
+				}
+
+				var logEntry = System.IO.File.ReadAllText(tmpFile);
+				// Scopes should not appear unless they are explicitly enabled.
+				Assert.DoesNotContain("Scope", logEntry);
+				Assert.Contains("\tMessage", logEntry);
+			} finally {
+				System.IO.File.Delete(tmpFile);
+			}
+		}
+
+		[Fact]
+		public void WriteNestedScopesInOuterToInnerOrder() {
+			var tmpFile = Path.GetTempFileName();
+			try {
+				using (var factory = new LoggerFactory()) {
+					factory.AddProvider(new FileLoggerProvider(tmpFile, new FileLoggerOptions() {
+						Append = false,
+						IncludeScopes = true
+					}));
+					var logger = factory.CreateLogger("TEST");
+					using (logger.BeginScope("Outer")) {
+						using (logger.BeginScope("Inner")) {
+							logger.LogInformation("Nested");
+						}
+						logger.LogInformation("Outer only");
+					}
+					logger.LogInformation("No scope");
+				}
+
+				var logEntries = System.IO.File.ReadAllLines(tmpFile);
+				// Disposing the inner scope should leave the outer scope active; disposing both should leave neither.
+				Assert.Equal("=> Outer => Inner", logEntries[0].Split('\t')[4]);
+				Assert.Equal("Nested", logEntries[0].Split('\t')[5]);
+
+				Assert.Equal("=> Outer", logEntries[1].Split('\t')[4]);
+				Assert.Equal("Outer only", logEntries[1].Split('\t')[5]);
+
+				Assert.Equal("No scope", logEntries[2].Split('\t')[4]);
+			} finally {
+				System.IO.File.Delete(tmpFile);
+			}
+		}
+
+		[Fact]
+		public void LoggerCreatedBeforeScopeProviderUsesScopes() {
+			var tmpFile = Path.GetTempFileName();
+			try {
+				using (var provider = new FileLoggerProvider(tmpFile, new FileLoggerOptions() {
+					Append = false,
+					IncludeScopes = true
+				})) {
+					var logger = provider.CreateLogger("TEST");
+					provider.SetScopeProvider(new LoggerExternalScopeProvider());
+					using (logger.BeginScope("Scope")) {
+						logger.LogInformation("Message");
+					}
+				}
+
+				// A logger created before SetScopeProvider should use the provider assigned later.
+				Assert.Contains("\t=> Scope\tMessage", System.IO.File.ReadAllText(tmpFile));
+			} finally {
+				System.IO.File.Delete(tmpFile);
+			}
+		}
+
+		[Fact]
+		public void CustomFormatLogEntryIgnoresScopes() {
+			var tmpFile = Path.GetTempFileName();
+			try {
+				using (var factory = new LoggerFactory()) {
+					factory.AddProvider(new FileLoggerProvider(tmpFile, new FileLoggerOptions() {
+						Append = false,
+						IncludeScopes = true,
+						FormatLogEntry = logMessage => $"Custom: {logMessage.Message}"
+					}));
+					var logger = factory.CreateLogger("TEST");
+					using (logger.BeginScope("Scope")) {
+						logger.LogInformation("Message");
+					}
+				}
+
+				Assert.Equal($"Custom: Message{Environment.NewLine}", System.IO.File.ReadAllText(tmpFile));
+			} finally {
+				System.IO.File.Delete(tmpFile);
+			}
+		}
 	}
 }

--- a/test/NReco.Logging.Tests/FileProviderTests.cs
+++ b/test/NReco.Logging.Tests/FileProviderTests.cs
@@ -594,7 +594,7 @@ namespace NReco.Logging.Tests
 		}
 
 		[Fact]
-		public void CustomFormatLogEntryIgnoresScopes() {
+		public void CustomFormatLogEntryDoesNotIncludeScopesByDefault() {
 			var tmpFile = Path.GetTempFileName();
 			try {
 				using (var factory = new LoggerFactory()) {
@@ -610,6 +610,79 @@ namespace NReco.Logging.Tests
 				}
 
 				Assert.Equal($"Custom: Message{Environment.NewLine}", System.IO.File.ReadAllText(tmpFile));
+			} finally {
+				System.IO.File.Delete(tmpFile);
+			}
+		}
+
+		[Fact]
+		public void CustomFormatLogEntryCanIncludeScopes() {
+			var tmpFile = Path.GetTempFileName();
+			try {
+				using (var factory = new LoggerFactory()) {
+					factory.AddProvider(new FileLoggerProvider(tmpFile, new FileLoggerOptions() {
+						Append = false,
+						IncludeScopes = true,
+						FormatLogEntry = logMessage => {
+							var scopes = new List<string>();
+							logMessage.ScopeProvider?.ForEachScope((scope, state) => state.Add(scope?.ToString()), scopes);
+							return $"[{String.Join(",", scopes)}] {logMessage.Message}";
+						}
+					}));
+					var logger = factory.CreateLogger("TEST");
+					using (logger.BeginScope("Outer"))
+					using (logger.BeginScope("Inner")) {
+						logger.LogInformation("Message");
+					}
+				}
+
+				Assert.Equal($"[Outer,Inner] Message{Environment.NewLine}", System.IO.File.ReadAllText(tmpFile));
+			} finally {
+				System.IO.File.Delete(tmpFile);
+			}
+		}
+
+		[Fact]
+		public void CustomFormatLogEntryHasNoScopeProviderWhenScopesDisabled() {
+			var tmpFile = Path.GetTempFileName();
+			try {
+				using (var factory = new LoggerFactory()) {
+					// IncludeScopes is the single opt-in, so a custom handler cannot reach scopes while it is off.
+					factory.AddProvider(new FileLoggerProvider(tmpFile, new FileLoggerOptions() {
+						Append = false,
+						IncludeScopes = false,
+						FormatLogEntry = logMessage => $"{logMessage.ScopeProvider == null}: {logMessage.Message}"
+					}));
+					var logger = factory.CreateLogger("TEST");
+					using (logger.BeginScope("Scope")) {
+						logger.LogInformation("Message");
+					}
+				}
+
+				Assert.Equal($"True: Message{Environment.NewLine}", System.IO.File.ReadAllText(tmpFile));
+			} finally {
+				System.IO.File.Delete(tmpFile);
+			}
+		}
+
+		[Fact]
+		public void CustomFormatLogEntryHasNoScopeProviderWithoutFactory() {
+			var tmpFile = Path.GetTempFileName();
+			try {
+				// A provider created directly is never handed a scope provider by a logging factory,
+				// so scopes stay unavailable even though they are enabled.
+				using (var provider = new FileLoggerProvider(tmpFile, new FileLoggerOptions() {
+					Append = false,
+					IncludeScopes = true,
+					FormatLogEntry = logMessage => $"{logMessage.ScopeProvider == null}: {logMessage.Message}"
+				})) {
+					var logger = provider.CreateLogger("TEST");
+					using (logger.BeginScope("Scope")) {
+						logger.LogInformation("Message");
+					}
+				}
+
+				Assert.Equal($"True: Message{Environment.NewLine}", System.IO.File.ReadAllText(tmpFile));
 			} finally {
 				System.IO.File.Delete(tmpFile);
 			}

--- a/test/NReco.Logging.Tests/StringLogEntryFormatterTests.cs
+++ b/test/NReco.Logging.Tests/StringLogEntryFormatterTests.cs
@@ -104,7 +104,7 @@ namespace NReco.Logging.Tests {
 				outerResult = formatter.LowAllocLogEntryFormat("test", dt, LogLevel.Information, new EventId(7), "Outer", null, scopeProvider);
 			}
 
-			// Despite both calls running on the same thread, each must retain its own scope builder and message.
+			// Despite both calls running on the same thread, each must retain its own scopes and message.
 			Assert.Equal($"{dt:o}\tINFO\t[test]\t[7]\t=> Scope\tInner", innerResult);
 			Assert.Equal($"{dt:o}\tINFO\t[test]\t[7]\t=> Scope\tOuter", outerResult);
 		}

--- a/test/NReco.Logging.Tests/StringLogEntryFormatterTests.cs
+++ b/test/NReco.Logging.Tests/StringLogEntryFormatterTests.cs
@@ -35,6 +35,95 @@ namespace NReco.Logging.Tests {
 			LowAllocLogEntryFormat("aaa", LogLevel.Trace, 0, String.Concat(Enumerable.Repeat("TestValue ", 1000)), "test");
 		}
 
+		[Fact]
+		public void LowAllocLogEntryFormatScopes() {
+			var formatter = StringLogEntryFormatter.Instance;
+			var scopeProvider = new LoggerExternalScopeProvider();
+			var dt = DateTime.UtcNow;
+			using (scopeProvider.Push("Outer"))
+			using (scopeProvider.Push("Inner")) {
+				var result = formatter.LowAllocLogEntryFormat("test", dt, LogLevel.Information, new EventId(7), "Message", null, scopeProvider);
+
+				// Nested scopes should render outer-to-inner immediately before the message.
+				Assert.Equal($"{dt:o}\tINFO\t[test]\t[7]\t=> Outer => Inner\tMessage", result);
+			}
+		}
+
+		[Fact]
+		public void LowAllocLogEntryFormatNoActiveScopes() {
+			var formatter = StringLogEntryFormatter.Instance;
+			var scopeProvider = new LoggerExternalScopeProvider();
+			var dt = DateTime.UtcNow;
+
+			var result = formatter.LowAllocLogEntryFormat("test", dt, LogLevel.Information, new EventId(7), "Message", null, scopeProvider);
+
+			// With no active scopes, the output should match the original formatter output.
+			Assert.Equal(formatter.LowAllocLogEntryFormat("test", dt, LogLevel.Information, new EventId(7), "Message", null), result);
+		}
+
+		[Fact]
+		public void LowAllocLogEntryFormatExceptionOnlyIncludesScopes() {
+			var formatter = StringLogEntryFormatter.Instance;
+			var scopeProvider = new LoggerExternalScopeProvider();
+			var dt = DateTime.UtcNow;
+			var exception = new InvalidOperationException("Error");
+			using (scopeProvider.Push("Scope")) {
+				var result = formatter.LowAllocLogEntryFormat("test", dt, LogLevel.Error, new EventId(7), null, exception, scopeProvider);
+
+				// An exception-only entry should still include its active scope.
+				Assert.Equal($"{dt:o}\tFAIL\t[test]\t[7]\t=> Scope\t{exception}{Environment.NewLine}", result);
+			}
+		}
+
+		[Fact]
+		public void LowAllocLogEntryFormatExceptionOnlyWithoutActiveScopes() {
+			var formatter = StringLogEntryFormatter.Instance;
+			var scopeProvider = new LoggerExternalScopeProvider();
+			var dt = DateTime.UtcNow;
+			var exception = new InvalidOperationException("Error");
+
+			var result = formatter.LowAllocLogEntryFormat("test", dt, LogLevel.Error, new EventId(7), null, exception, scopeProvider);
+
+			Assert.Equal(formatter.LowAllocLogEntryFormat("test", dt, LogLevel.Error, new EventId(7), null, exception), result);
+		}
+
+		[Fact]
+		public void LowAllocLogEntryFormatReentrantScopeToString() {
+			var formatter = StringLogEntryFormatter.Instance;
+			var scopeProvider = new LoggerExternalScopeProvider();
+			var dt = DateTime.UtcNow;
+			string innerResult = null;
+			var scope = new ReentrantScope("Scope", onFirstToString: () => {
+				// Appending a scope calls its user-defined ToString(), which may itself log.
+				// Simulate that by formatting another entry before the outer call has finished.
+				innerResult = formatter.LowAllocLogEntryFormat("test", dt, LogLevel.Information, new EventId(7), "Inner", null, scopeProvider);
+			});
+
+			string outerResult;
+			using (scopeProvider.Push(scope)) {
+				outerResult = formatter.LowAllocLogEntryFormat("test", dt, LogLevel.Information, new EventId(7), "Outer", null, scopeProvider);
+			}
+
+			// Despite both calls running on the same thread, each must retain its own scope builder and message.
+			Assert.Equal($"{dt:o}\tINFO\t[test]\t[7]\t=> Scope\tInner", innerResult);
+			Assert.Equal($"{dt:o}\tINFO\t[test]\t[7]\t=> Scope\tOuter", outerResult);
+		}
+
+		[Fact]
+		public void LowAllocLogEntryFormatLongAndNullScopes() {
+			var formatter = StringLogEntryFormatter.Instance;
+			var scopeProvider = new LoggerExternalScopeProvider();
+			var dt = DateTime.UtcNow;
+			var longScope = String.Concat(Enumerable.Repeat("Scope", 1000));
+			using (scopeProvider.Push(null))
+			using (scopeProvider.Push(longScope)) {
+				var result = formatter.LowAllocLogEntryFormat("test", dt, LogLevel.Information, new EventId(7), "Message", null, scopeProvider);
+
+				// Null scopes should render consistently, and long scopes should not be truncated.
+				Assert.Equal($"{dt:o}\tINFO\t[test]\t[7]\t=>  => {longScope}\tMessage", result);
+			}
+		}
+
 
 		[Fact]
 		public void GetFormattedLengthOfZero() {
@@ -226,6 +315,24 @@ namespace NReco.Logging.Tests {
 			Assert.True(span.SequenceEqual(expected));
 		}
 
+		private sealed class ReentrantScope {
+			private readonly string value;
+			private readonly Action onFirstToString;
+			private bool hasFormatted;
+
+			public ReentrantScope(string value, Action onFirstToString) {
+				this.value = value;
+				this.onFirstToString = onFirstToString;
+			}
+
+			public override string ToString() {
+				if (!hasFormatted) {
+					hasFormatted = true;
+					onFirstToString();
+				}
+				return value;
+			}
+		}
 
 	}
 }


### PR DESCRIPTION
> This pull request was created by GitHub Copilot, which wrote the code with human supervision

This adds opt-in logging scope support as requested in #77. Setting `IncludeScopes` adds active scopes as a tab-separated field before the message, formatted in ConsoleLogger-style outer-to-inner order: `=> Outer => Inner`. Scopes are disabled by default, and entries without active scopes retain the existing output. Scope context is also included on exception-only entries.

The main technical constraint is that `IExternalScopeProvider` exposes scopes only through its callback-based `ForEachScope` API, while the existing low-allocation `ValueStringBuilder` is a `ref struct` and cannot be captured or passed as callback state. Scopes are therefore collected into a reusable list and then appended directly to the final buffer, which also keeps the exact output length known up front so the buffer is still rented once. The list holds one entry per active scope, so its capacity stays as small as the scope nesting. It is checked out while in use so logging from a scope's `ToString()` cannot corrupt another entry being formatted on the same thread.

`FileLoggerProvider` implements `ISupportExternalScope`, allowing `LoggerFactory` to supply the shared provider that tracks `BeginScope()` state across nesting, disposal, and asynchronous flow. `FileLogger.BeginScope()` delegates to it for direct logger usage. A custom `FormatLogEntry` delegate replaces the built-in format entirely, so it renders scopes itself through the new `LogMessage.ScopeProvider` field. That field is populated only while `IncludeScopes` is enabled, so the option stays the single opt-in for scope handling rather than becoming a no-op for custom formatters. `FilterLogEntry` receives the same value and can therefore filter on scopes as well.

Documentation and tests cover configuration, scope ordering and lifetime, exceptions, custom formatting, long and null scopes, and logging during scope formatting. The library, tests, and examples build successfully, and all 50 tests pass on `net481`, `net8.0`, and `net10.0`.

Fixes #77
